### PR TITLE
added the subject endpoint with tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+     */virtualenv/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - 'rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION'
   - pip install .
   - pip install -r requirements.txt
+  - pip install coveralls
   - npm install
 
 script:
@@ -39,3 +40,6 @@ script:
  - npm -v
  - npm run build
  - bin/tests --dbfixtures-config tests/dbfixtures.travis.conf
+
+after_success:
+  coveralls

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![build status](https://travis-ci.org/openstax/research-p3-experiment-4.svg?branch=master)](https://travis-ci.org/openstax/research-p3-experiment-4.svg?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/openstax/research-p3-experiment-4/badge.svg?branch=master)](https://coveralls.io/github/openstax/research-p3-experiment-4?branch=master)
+
 # Personalized Practice Problems (P3) Experiment #4
 
 The documentation for this project is located on the Open Science Framework website.

--- a/bin/tests
+++ b/bin/tests
@@ -8,6 +8,4 @@ set -x
 export LC_ALL="${ENCODING:-en_US.UTF-8}"
 export LANG="${ENCODING:-en_US.UTF-8}"
 
-python -m coverage run -m pytest --strict $@
-python -m coverage report -m
-python -m coverage html
+python -m pytest --strict  $@

--- a/digital_logic/__init__.py
+++ b/digital_logic/__init__.py
@@ -1,5 +1,5 @@
 from . import factory
-
+from .utils import make_database_url
 
 def create_app(settings_override=None):
     return factory.create_app(__name__,

--- a/digital_logic/api/api.py
+++ b/digital_logic/api/api.py
@@ -1,10 +1,37 @@
+import logging
+import traceback
+
 from flask import Blueprint
-from ..core import api
+from flask import current_app
+from sqlalchemy.orm.exc import NoResultFound
 
 from .endpoints.ping import ns as ping_namespace
+from .endpoints.subjects import ns as subjects_namespace
+from ..core import api
+
+log = logging.getLogger(__name__)
 
 bp = Blueprint('api', __name__, url_prefix='/api/v1')
 
 api.init_app(bp)
 
+# Add namespaces
 api.add_namespace(ping_namespace)
+api.add_namespace(subjects_namespace)
+
+
+# register error handlers
+@api.errorhandler
+def default_error_handler(e):
+    message = 'An unhandled exception occurred.'
+    log.exception(message)
+
+    if not current_app.config['FLASK_DEBUG']:
+        return {'message': message}, 500
+
+
+@api.errorhandler(NoResultFound)
+def database_not_found_error_handler(e):
+    log.warning(traceback.format_exc())
+    return {
+               'message': 'A database result was required but none was found.'}, 404

--- a/digital_logic/api/endpoints/subjects.py
+++ b/digital_logic/api/endpoints/subjects.py
@@ -1,15 +1,69 @@
+from flask import request
 from flask_restplus import Resource
 
+from digital_logic.api.serializers import subject
 from digital_logic.core import api
+from digital_logic.models import Subject, create_subject, update_subject
 
-ns = api.namespace('subjects', description='Operations related to experiment '
-                                           'subjects')
+ns = api.namespace('subjects',
+                   description='Operations related to experiment subjects')
 
 
 @ns.route('/')
 class SubjectCollection(Resource):
+    """
+    Shows a list of all subjects, and allows a POST to create new subjects
+    """
+
+    @ns.marshal_list_with(subject, envelope='collection')
     def get(self):
         """
         Returns a list of subjects
         """
-        pass
+        return Subject.all()
+
+    @ns.doc('create_subject')
+    @ns.expect(subject, validate=True)
+    @ns.marshal_with(subject, code=201)
+    def post(self):
+        """
+        Creates a subject and returns the created item
+        """
+        sub = create_subject(request.json)
+        return sub, 201
+
+
+@ns.route('/<int:subject_id>')
+@ns.response(404, 'Subject not found')
+@ns.param('subject_id', 'The subject identifier')
+class SubjectItem(Resource):
+    """Show a single subject. A delete is not allowed"""
+
+    @ns.doc('get_subject')
+    @ns.marshal_with(subject)
+    def get(self, subject_id):
+        """
+        Returns a subject item
+        """
+        return Subject.get(subject_id)
+
+    @ns.expect(subject)
+    @ns.marshal_with(subject)
+    @ns.response(204, 'Subject successfully updated.')
+    def put(self, subject_id):
+        """
+        Updates a subject's data in the database
+
+        * Send a JSON object with the new item in the request body.
+
+        ```
+        {
+            "worker_id": "debug231G32"
+        }
+        ```
+
+        * Specify the Subject_id of the subject to modify in the request URL path.
+        """
+        posted = request.get_json()
+        sub = update_subject(subject_id, posted)
+        return sub, 204

--- a/digital_logic/api/serializers.py
+++ b/digital_logic/api/serializers.py
@@ -1,0 +1,20 @@
+from flask_restplus import fields
+
+from ..core import api
+
+subject = api.model('Subject', {
+    'id': fields.Integer(readonly=True,
+                         description='The unique id of the subject'),
+    'assignment_id': fields.String(required=True,
+                                   description='The assignment_id of the assignment in Mechanical Turk'),
+    'external_id': fields.String(required=True,
+                                 description='The id of the subject to be used in other systems'),
+    'worker_id': fields.String(required=True,
+                               description='The worker_id of the subject on Mechanical Turk'),
+    'hit_id': fields.String(required=True,
+                            description='The hit_id on Mechanical Turk'),
+    'experiment_group': fields.String(required=True,
+                                      description='The experiment group the subject is in'),
+    'assignment_name': fields.String(required=True,
+                                     description='The name of the assignment')
+})

--- a/digital_logic/experiment/models.py
+++ b/digital_logic/experiment/models.py
@@ -3,13 +3,30 @@ from datetime import datetime
 from ..core import db
 
 
+def create_subject(data):
+    subject = Subject(**data)
+    db.session.add(subject)
+    db.session.commit()
+
+    return subject
+
+
+def update_subject(subject_id, data):
+    subject = Subject.get(subject_id)
+
+    for k, v in data.items():
+        setattr(subject, k, v)
+
+    db.session.add(subject)
+    db.session.commit()
+
+    return subject
+
+
 class Subject(db.Model):
     __tablename__ = 'subjects'
     __table_args__ = (db.UniqueConstraint('assignment_id', 'worker_id',
                                           name='worker_id_assignment_id_uix'),)
-    __json_public__ = None
-    __json_hidden__ = None
-    __json_modifiers__ = None
 
     id = db.Column(db.Integer(), primary_key=True)
     external_id = db.Column(db.String(128))
@@ -35,14 +52,8 @@ class Subject(db.Model):
 
     @classmethod
     def get(cls, id):
-        return db.session.query(cls).get(id)
+        return db.session.query(cls).filter(cls.id == id).one()
 
     @classmethod
     def get_by_worker_id(cls, worker_id):
         return db.session.query(cls).filter(cls.worker_id == worker_id).first()
-
-    def get_field_names(self):
-        for p in self.__mapper__.iterate_properties:
-            yield p.key
-
-

--- a/digital_logic/factory.py
+++ b/digital_logic/factory.py
@@ -1,11 +1,14 @@
-from flask import Blueprint
 from flask import Flask
 from flask_security import SQLAlchemyUserDatastore
 
 from .accounts.models import User, Role
-from .core import api, db, security, mail, webpack
+from .core import (db,
+                   security,
+                   mail,
+                   webpack)
 from .helpers import register_blueprints
 from .redis_session import RedisSessionInterface
+
 
 def create_app(package_name, package_path, settings_override=None):
     """

--- a/digital_logic/utils.py
+++ b/digital_logic/utils.py
@@ -1,0 +1,11 @@
+import os
+
+
+def make_database_url():
+    return 'postgresql+psycopg2://{0}:{1}@{2}:{3}/{4}'.format(
+        os.getenv('DB_USER', "postgres"),
+        os.getenv('DB_PASSWORD', ''),
+        os.getenv('DB_HOST', '127.0.0.1'),
+        os.getenv('DB_PORT', '5432'),
+        os.getenv('DB_NAME', 'tests'),
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
     environment:
       CONFIG_ENV: development
       SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://postgres@db/app
+      DB_USER: postgres
+      DB_HOST: db
+      DB_NAME: app
       REDIS_HOST: redis
       FLASK_DEBUG: 'True'
       FLASK_APP: /app/wsgi.py

--- a/instance/config.py
+++ b/instance/config.py
@@ -1,6 +1,7 @@
 import os
 
-# Flask specific
+from digital_logic import make_database_url
+
 SECRET_KEY = os.environ.get('SESSION_SECRET')
 DEBUG = os.environ.get('FLASK_DEBUG')
 
@@ -9,7 +10,7 @@ REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
 
 # Flask-SQLAlchemy
 SQLALCHEMY_TRACK_MODIFICATIONS = True
-SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI')
+SQLALCHEMY_DATABASE_URI = make_database_url()
 
 # Flask-Mail
 MAIL_PASSWORD = ''

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,24 +1,19 @@
 from __future__ import with_statement
 
 import os
+import sys
+from logging.config import fileConfig
 from os.path import dirname, abspath
 
-import sys
 from alembic import context
-
 from sqlalchemy import create_engine
-from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig
+
+from digital_logic import make_database_url
 
 sys.path.append(dirname(dirname(abspath(__file__))))
 sys.path.append(os.getcwd())
 
-from digital_logic.models import *
 from digital_logic.core import db
-from digital_logic import create_app
-
-
-app = create_app()
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -39,17 +34,6 @@ target_metadata = db.metadata
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
-# def get_url():
-#     return "postgresql+psycopg2://{0}:{1}@{2}/{3}".format(
-#         os.getenv("DB_USER", "postgresql"),
-#         os.getenv("DB_PASSWORD", "password"),
-#         os.getenv("DB_HOST", "localhost"),
-#         os.getenv("DB_NAME", "postgresql"),
-#     )
-
-def get_url():
-    return app.config['SQLALCHEMY_DATABASE_URI']
-
 
 def run_migrations_offline():
     """Run migrations in 'offline' mode.
@@ -63,7 +47,7 @@ def run_migrations_offline():
     script output.
 
     """
-    url = get_url()
+    url = make_database_url()
     context.configure(
         url=url, target_metadata=target_metadata, literal_binds=True)
 
@@ -78,7 +62,7 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
-    connectable = create_engine(get_url())
+    connectable = create_engine(make_database_url())
 
     with connectable.connect() as connection:
         context.configure(

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ universal = 1
 description-file = README.md
 
 [tool:pytest]
-addopts = --verbose --cov=digital_logic/ tests/
+addopts = --verbose --cov=digital_logic/ --cov-report=xml:cov.xml tests/
+norecursedirs = build docs/_build *.egg .tox *.venv /home/travis/virtualenv
 
 [aliases]
 test=pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import psycopg2
 import pytest
+from alembic.command import upgrade
+from alembic.config import Config as AlembicConfig
 from pytest_dbfixtures.factories.postgresql import init_postgresql_database, \
     drop_postgresql_database
 from pytest_dbfixtures.utils import get_config
@@ -7,28 +9,63 @@ from pytest_factoryboy import register
 from webtest import TestApp
 
 from digital_logic import create_app
-from digital_logic.core import db
+from digital_logic.core import db as _db
 from factories import UserFactory
 
 # Use the pytest_factory_boy plugin and register the Model Factory
 register(UserFactory)
 
 
-@pytest.yield_fixture(scope='function')
-def app():
-    """An application for the tests."""
+@pytest.fixture(scope='session')
+def config_database(request):
+    connection_string = 'postgresql+psycopg2://{0}@{1}:{2}/{3}'
+
+    config = get_config(request)
+    pg_host = config.postgresql.host
+    pg_port = config.postgresql.port
+    pg_user = config.postgresql.user
+    pg_db = config.postgresql.db
+
+    # Create the database
+    init_postgresql_database(psycopg2, pg_user, pg_host, pg_port, pg_db)
+
+    # Ensure the database gets deleted
+    @request.addfinalizer
+    def drop_database():
+        drop_postgresql_database(
+            psycopg2, pg_user, pg_host, pg_port, pg_db, '9.4'
+        )
+
+    return connection_string.format(pg_user, pg_host, pg_port, pg_db)
+
+
+@pytest.fixture(scope='session')
+def app_config(config_database):
+    print('Loading config')
     settings = {
         'TESTING': True,
         'SECRET_KEY': 'a key for testing',
         'DEBUG': False,
-        'SQLALCHEMY_DATABASE_URI': 'postgresql+psycopg2://postgres@localhost:5432/tests',
+        'SQLALCHEMY_DATABASE_URI': config_database,
         'WTF_CSRF_ENABLED': False,
         'SECURITY_REGISTERABLE': False,
-        'WEBPACK_MANIFEST_PATH' : '../digital_logic/build/manifest.json'
+        'WEBPACK_MANIFEST_PATH': '../digital_logic/build/manifest.json'
     }
 
+    # Ensure our migrations have been ran.
+    # alembic.command.upgrade(config.alembic_config(), "head")
+    config = AlembicConfig('alembic.ini')
+    upgrade(config, 'head')
+
+    return settings
+
+
+@pytest.yield_fixture(scope='function')
+def app(app_config):
+    """An application for the tests."""
+
     _app = create_app()
-    _app.config.update(settings)
+    _app.config.update(app_config)
 
     ctx = _app.test_request_context()
     ctx.push()
@@ -44,30 +81,18 @@ def test_client(app):
 
 
 @pytest.yield_fixture(scope='function')
-def database(app, request):
+def db(app, request):
     """The database used for testing"""
-    db.app = app
-    config = get_config(request)
-    pg_host = config.postgresql.host
-    pg_port = config.postgresql.port
-    pg_user = config.postgresql.user
-    pg_db = config.postgresql.db
+    _db.app = app
 
-    init_postgresql_database(psycopg2, pg_user, pg_host, pg_port, pg_db)
+    yield _db
 
-    with app.app_context():
-        db.create_all()
-
-    yield db
-
-    db.session.close()
-
-    drop_postgresql_database(psycopg2, pg_user, pg_host, pg_port, pg_db, '9.4')
+    _db.session.close()
 
 
 @pytest.fixture(scope='function')
-def user(database, user_factory):
+def user(db, user_factory):
     """A user for the tests"""
     _user = user_factory(password='iH3@r7P1zz@')
-    database.session.commit()
+    db.session.commit()
     return _user

--- a/tests/test_api_ping.py
+++ b/tests/test_api_ping.py
@@ -1,0 +1,3 @@
+def test_ping(test_client):
+    response = test_client.get('/api/v1/ping/')
+    assert response.json == {'message': 'pong'}

--- a/tests/test_api_subjects.py
+++ b/tests/test_api_subjects.py
@@ -1,0 +1,122 @@
+RESOURCE = '/api/v1/subjects/'
+
+post_data = {
+    'external_id': '931d8a79ec56394ed73d38e754390988',
+    'assignment_id': 'debugSIP7SD',
+    'assignment_name': 'test assignment',
+    'worker_id': 'debugT7MSZ2',
+    'hit_id': 'debugVY4J2G',
+    'experiment_group': 'test',
+}
+
+
+def post_data_copy():
+    data = dict()
+    data.update(post_data)
+    return data
+
+
+def test_api_subject_post_successful(test_client):
+    subject = post_data_copy()
+    response = test_client.post_json(RESOURCE, subject)
+    assert response.status_code == 201
+
+
+def test_api_subject_post_validation_assignment_id_missing(test_client):
+    subject = post_data_copy()
+    del subject['assignment_id']
+    response = test_client.post_json(RESOURCE, subject, expect_errors=True)
+
+    assert response.status_code == 400
+
+    response = response.json
+
+    assert response['errors'][
+               'assignment_id'] == "'assignment_id' is a required property"
+
+
+def test_api_subject_post_validation_worker_id_missing(test_client):
+    subject = post_data_copy()
+    del subject['worker_id']
+    response = test_client.post_json(RESOURCE, subject, expect_errors=True)
+
+    assert response.status_code == 400
+
+    response = response.json
+
+    assert response['errors'][
+               'worker_id'] == "'worker_id' is a required property"
+
+
+def test_api_subject_post_validation_external_id_missing(test_client):
+    subject = post_data_copy()
+    del subject['external_id']
+    response = test_client.post_json(RESOURCE, subject, expect_errors=True)
+
+    assert response.status_code == 400
+
+    response = response.json
+
+    assert response['errors'][
+               'external_id'] == "'external_id' is a required property"
+
+
+def test_api_subject_post_validation_experiment_group_missing(test_client):
+    subject = post_data_copy()
+    del subject['experiment_group']
+    response = test_client.post_json(RESOURCE, subject, expect_errors=True)
+
+    assert response.status_code == 400
+
+    response = response.json
+
+    assert response['errors'][
+               'experiment_group'] == "'experiment_group' is a required property"
+
+
+def test_api_subject_post_validation_hit_id_missing(test_client):
+    subject = post_data_copy()
+    del subject['hit_id']
+    response = test_client.post_json(RESOURCE, subject, expect_errors=True)
+
+    assert response.status_code == 400
+
+    response = response.json
+
+    assert response['errors']['hit_id'] == "'hit_id' is a required property"
+
+
+def test_api_subject_post_validation_experiment_group_missing(test_client):
+    subject = post_data_copy()
+    del subject['assignment_name']
+    response = test_client.post_json(RESOURCE, subject, expect_errors=True)
+
+    assert response.status_code == 400
+
+    response = response.json
+
+    assert response['errors'][
+               'assignment_name'] == "'assignment_name' is a required property"
+
+
+def test_api_subjects_get_all_successful(test_client):
+    response = test_client.get(RESOURCE)
+    assert response.status_code == 200
+    response = response.json
+    assert len(response) > 0
+
+
+def test_api_subjects_get_one_successfull(test_client):
+    response = test_client.get(RESOURCE + '1')
+    assert response.status_code == 200
+
+
+def test_api_subjects_put_successful(test_client):
+    data = {
+        "worker_id": "debug231G32"
+    }
+    response = test_client.put_json(RESOURCE + '1', params=data)
+    assert response.status_code == 204
+    response = test_client.get(RESOURCE + '1')
+    response = response.json
+    assert response['worker_id'] == 'debug231G32'

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,3 +1,3 @@
-def test_dashboard_redirect(user, test_client):
+def test_dashboard_login_required_redirect(test_client):
     response = test_client.get('/')
     assert response.status_code == 302


### PR DESCRIPTION
- added subjects get, post, and put endpoints.
- added coveralls to travis.yml
- refactored get_url to use env vars for creation of the connection string for alembic and database fixtures
- renamed api decorator to namespace in subjects endpoints
- added error handlers and subjects namespace to api
- added config_database and app_config fixtures to tests with session scope
- added DB_USER, DB_HOST, and DB_NAME to docker-compose.yml
- added create and update subject/business
- logic to models.py
- added travis build badge to README
- added coveralls badge to README
- added subject flask-restplus model for marshalling and validation
- added test for ping
