### PR TITLE
fixed webpack-dev-server from causing high cpu usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "webpack-dev-server --port 2992 --content-base digital_logic/build/public --hot",
+    "start": "webpack-dev-server --port 2992 --content-base digital_logic/build/public --hot --watch --inline",
     "build": "webpack --display-error-details --progress --profile --colors"
   },
   "author": "m1yag1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,8 +37,8 @@ module.exports = {
       }
     },
     watchOptions: {
-      //poll: true
-      poll: false
+      poll: 500,
+      ignored: /node_modules/
     }
   },
   resolve: {


### PR DESCRIPTION
- the webpack-dev-server was causing high cpu usage because of file polling
  and the use of docker. The poll parameter in watchOptions was given a 500ms delay when polling
  to reduce the cpu usage to tolerable levels.
- node_modules was added to watchOptions
- added --inline option to npm start command
- fixes #6 
