### PR TITLE
switch from coveralls to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - 'rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION'
   - pip install .
   - pip install -r requirements.txt
+  - pip install codecov
   - npm install
 
 script:
@@ -42,4 +43,4 @@ script:
 
 after_success:
   # Report coverage to codecov
-  - bash <(curl -s https://codecov.io/bash)
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ install:
   - 'rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION'
   - pip install .
   - pip install -r requirements.txt
-  - pip install coveralls
   - npm install
 
 script:
@@ -42,4 +41,5 @@ script:
  - python setup.py test
 
 after_success:
-  coveralls
+  # Report coverage to codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![build status](https://travis-ci.org/openstax/research-p3-experiment-4.svg?branch=master)](https://travis-ci.org/openstax/research-p3-experiment-4.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/openstax/research-p3-experiment-4/badge.svg?branch=master)](https://coveralls.io/github/openstax/research-p3-experiment-4?branch=master)
+[![Coverage][codecov-image]][codecov-url]
+
 
 # Personalized Practice Problems (P3) Experiment #4
 
@@ -21,3 +22,6 @@ $ make build
 $ # Start up the local environment
 $ make serve
 ```
+
+[codecov-image]: https://img.shields.io/codecov/c/github/connexions/esearch-p3-experiment-4.svg
+[codecov-url]: https://codecov.io/gh/Connexions/esearch-p3-experiment-4

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ $ # Start up the local environment
 $ make serve
 ```
 
-[codecov-image]: https://img.shields.io/codecov/c/github/connexions/esearch-p3-experiment-4.svg
-[codecov-url]: https://codecov.io/gh/Connexions/esearch-p3-experiment-4
+[codecov-image]: https://img.shields.io/codecov/c/github/openstax/research-p3-experiment-4.svg
+[codecov-url]: https://codecov.io/gh/openstax/research-p3-experiment-4


### PR DESCRIPTION
As part of https://github.com/openstax/napkin-notes/issues/68 this switches from coveralls to codecov.

I was not sure about a couple things but took some defaults:

- When should coveralls make comments on the PR and what should be included
- I used this recommendation from codecov.io: https://github.com/codecov/example-python
